### PR TITLE
Expense approvals

### DIFF
--- a/src/apps/finance/admin/dashboard/expense_approvals/expense_approvals.js
+++ b/src/apps/finance/admin/dashboard/expense_approvals/expense_approvals.js
@@ -41,14 +41,9 @@ class ExpenseApprovals extends React.Component {
     const { config, isExpanded } = this.props
     return {
       endpoint: '/api/admin/finance/approvals',
-      query: {
-        $filter: {
-          status: {
-            $in: ['submitted']
-          }
-        },
-        $page: {
-          limit: 0
+      filter: {
+        status: {
+          $eq: 'submitted'
         }
       },
       layout: Results,
@@ -61,7 +56,18 @@ class ExpenseApprovals extends React.Component {
 }
 
 const mapResources = (props, context) => ({
-  items: '/api/admin/finance/approvals'
-})
+  items: {
+    endpoint: '/api/admin/finance/approvals',
+    query: {
+      $filter: {
+        status: {
+          $in: ['submitted']
+        }
+      },
+      $page: {
+        limit: 0
+      }
+    }
+  }})
 
 export default Container(mapResources)(ExpenseApprovals)

--- a/src/apps/finance/admin/dashboard/expense_approvals/expense_approvals.js
+++ b/src/apps/finance/admin/dashboard/expense_approvals/expense_approvals.js
@@ -1,0 +1,67 @@
+import { Infinite, Container } from 'maha-admin'
+import PropTypes from 'prop-types'
+import pluralize from 'pluralize'
+import Results from './results'
+import React from 'react'
+
+class ExpenseApprovals extends React.Component {
+
+  static contextTypes = {
+    admin: PropTypes.object,
+    router: PropTypes.object
+  }
+
+  static propTypes = {
+    config: PropTypes.object,
+    controls: PropTypes.any,
+    items: PropTypes.array,
+    isExpanded: PropTypes.bool
+  }
+
+  render() {
+    const { controls, items } = this.props
+
+    return (
+      <div className="maha-dashboard-card">
+        <div className="maha-dashboard-card-header">
+          <div className="maha-dashboard-card-header-details">
+            <h2>Expense Approvals</h2>
+            <h3>You have { items.length } { pluralize('approval', items.length) }</h3>
+          </div>
+          { controls }
+        </div>
+        <div className="maha-dashboard-card-body">
+          <Infinite { ...this._getInfinite() } />
+        </div>
+      </div>
+    )
+  }
+
+  _getInfinite() {
+    const { config, isExpanded } = this.props
+    return {
+      endpoint: '/api/admin/finance/approvals',
+      query: {
+        $filter: {
+          status: {
+            $in: ['submitted']
+          }
+        },
+        $page: {
+          limit: 0
+        }
+      },
+      layout: Results,
+      props: {
+        config,
+        isExpanded
+      }
+    }
+  }
+}
+
+const mapResources = (props, context) => ({
+  items: '/api/admin/finance/approvals'
+})
+
+export default Container(mapResources)(ExpenseApprovals)

--- a/src/apps/finance/admin/dashboard/expense_approvals/index.js
+++ b/src/apps/finance/admin/dashboard/expense_approvals/index.js
@@ -1,0 +1,8 @@
+import ExpenseApprovals from './expense_approvals'
+
+const card = {
+  code: 'expense_approvals',
+  component: ExpenseApprovals
+}
+
+export default card

--- a/src/apps/finance/admin/dashboard/expense_approvals/results.js
+++ b/src/apps/finance/admin/dashboard/expense_approvals/results.js
@@ -1,0 +1,48 @@
+import CompactTypeToken from '../../tokens/type/compact'
+import { Format } from 'maha-admin'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+class Results extends React.Component {
+
+  static contextTypes = {
+    card: PropTypes.object,
+    router: PropTypes.object
+  }
+
+  static propTypes = {
+    config: PropTypes.object,
+    records: PropTypes.array,
+    isExpanded: PropTypes.bool
+  }
+
+  render() {
+    const { records, isExpanded } = this.props
+    return (
+      <div className="maha-list">
+        { records.map((item, index) => (
+          <div className="maha-list-item maha-list-item-link" key={`item_${index}`} onClick={ this._handleItem.bind(this, item) }>
+            <div className="maha-list-item-token">
+              <CompactTypeToken value={ item.type } />
+            </div>
+            <div className="maha-list-item-label">
+              { item.user.full_name }, ${ item.amount } { isExpanded && `, ${item.description}` }
+            </div>
+            <div className="maha-list-item-data">
+              <Format value={ item.created_at } format='date' />
+            </div>
+            <div className="maha-list-item-proceed">
+              <i className="fa fa-chevron-right" />
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  _handleItem(item) {
+    this.context.router.history.push(`/admin/finance/expenses/${item.id}`)
+  }
+}
+
+export default Results

--- a/src/apps/finance/admin/dashboard/index.js
+++ b/src/apps/finance/admin/dashboard/index.js
@@ -8,6 +8,10 @@ const dashboard = [
     code: 'new_item',
     title: 'New Expense',
     description: 'Submit a new expense'
+  }, {
+    code: 'expense_approvals',
+    title: 'Expense Approvals',
+    description: 'Summary of finance items to approve'
   }
 ]
 

--- a/src/core/admin/app.js
+++ b/src/core/admin/app.js
@@ -170,6 +170,7 @@ import crmAdminDashboardEmailsIndexJs from '../../apps/crm/admin/dashboard/email
 import crmAdminDashboardFormIndexJs from '../../apps/crm/admin/dashboard/form/index.js'
 import eventsAdminDashboardEventDetailIndexJs from '../../apps/events/admin/dashboard/event_detail/index.js'
 import financeAdminDashboardAdminTasksIndexJs from '../../apps/finance/admin/dashboard/admin_tasks/index.js'
+import financeAdminDashboardExpenseApprovalsIndexJs from '../../apps/finance/admin/dashboard/expense_approvals/index.js'
 import financeAdminDashboardNewItemIndexJs from '../../apps/finance/admin/dashboard/new_item/index.js'
 import mahaAdminDashboardGreetingIndexJs from '../../apps/maha/admin/dashboard/greeting/index.js'
 import financeSettings from '../../apps/finance/admin/settings.js'
@@ -277,6 +278,12 @@ class App extends React.Component {
         app: 'finance',
         type: financeAdminDashboardAdminTasksIndexJs.code,
         code: 'finance:'+financeAdminDashboardAdminTasksIndexJs.code
+      },
+      {
+        ...financeAdminDashboardExpenseApprovalsIndexJs,
+        app: 'finance',
+        type: financeAdminDashboardExpenseApprovalsIndexJs.code,
+        code: 'finance:'+financeAdminDashboardExpenseApprovalsIndexJs.code
       },
       {
         ...financeAdminDashboardNewItemIndexJs,

--- a/src/core/admin/components/list/style.less
+++ b/src/core/admin/components/list/style.less
@@ -42,6 +42,9 @@
 .maha-list-item-unit {
   margin-left: 3px;
 }
+.maha-list-item-token {
+  padding-left: 0.8em;
+}
 .maha-list-item-padded {
   padding: 0.8em;
   flex: 1;


### PR DESCRIPTION
Hey @mochini 
Here's a pretty straightforward expense approvals card. I included a list of expense items with abbreviated data (some extra data if isExpanded). I figured this would be a little more substantial and useful than a single line that reads "You have 20 expense items to review". Even if users just glance at the data and step into the (new) approval flow with their first click.

The only thing I haven't figured out here is access control. Looks like the [app list](https://github.com/mahaplatform/mahaplatform.com/blob/master/src/apps/finance/admin/views/items/approvals.js#L15) has an attempt at this that is commented out?